### PR TITLE
Change history package to 1.17.x to satisfy peer dependencies require…

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "js-cookie": "^2.0.4",
     "cookie": "^0.2.3",
     "extend": "^3.0.0",
-    "history": "1.13.x",
+    "history": "1.17.x",
     "immutable": "^3.7.5",
     "isomorphic-fetch": "^2.1.1",
     "node-fetch": "^1.3.3",


### PR DESCRIPTION
Change history package to 1.17.x to satisfy peer dependencies requirement of react-router 1.0.3