### PR TITLE
Fix webpack config to allow default theme to function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,18 +68,5 @@ export {
   hideDestroyAccountErrorModal
 } from "./actions/ui";
 
-/* UI */
-export {
-  AuthGlobals,
-  EmailSignInForm,
-  EmailSignUpForm,
-  SignOutButton,
-  RequestPasswordResetForm,
-  OAuthSignInButton,
-  UpdatePasswordForm,
-  DestroyAccountButton,
-  TokenBridge
-} from "./views/default";
-
 /* utils */
 export {default as fetch} from "./utils/fetch";

--- a/src/views/bootstrap/DestroyAccountButton.js
+++ b/src/views/bootstrap/DestroyAccountButton.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
 import ButtonLoader from "./ButtonLoader";
-import { destroyAccount } from "../../actions/destroy-account";
+import { destroyAccount } from "redux-auth/actions/destroy-account";
 import { connect } from "react-redux";
 import { Glyphicon } from "react-bootstrap";
 

--- a/src/views/bootstrap/EmailSignInForm.js
+++ b/src/views/bootstrap/EmailSignInForm.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from "react";
 import ButtonLoader from "./ButtonLoader";
 import Input from "./Input";
-import { emailSignInFormUpdate, emailSignIn } from "../../actions/email-sign-in";
+import { emailSignInFormUpdate, emailSignIn } from "redux-auth/actions/email-sign-in";
 import { Glyphicon } from "react-bootstrap";
 import { connect } from "react-redux";
 

--- a/src/views/bootstrap/EmailSignUpForm.js
+++ b/src/views/bootstrap/EmailSignUpForm.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import Input from "./Input";
 import ButtonLoader from "./ButtonLoader";
-import { emailSignUpFormUpdate, emailSignUp } from "../../actions/email-sign-up";
+import { emailSignUpFormUpdate, emailSignUp } from "redux-auth/actions/email-sign-up";
 import { connect } from "react-redux";
 import { Glyphicon } from "react-bootstrap";
 

--- a/src/views/bootstrap/OAuthSignInButton.js
+++ b/src/views/bootstrap/OAuthSignInButton.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react";
 import { connect } from "react-redux";
 import ButtonLoader from "./ButtonLoader";
 import { Glyphicon } from "react-bootstrap";
-import { oAuthSignIn as _oAuthSignIn } from "../../actions/oauth-sign-in";
+import { oAuthSignIn as _oAuthSignIn } from "redux-auth/actions/oauth-sign-in";
 
 // hook for rewire
 var oAuthSignIn = _oAuthSignIn;

--- a/src/views/bootstrap/RequestPasswordResetForm.js
+++ b/src/views/bootstrap/RequestPasswordResetForm.js
@@ -6,7 +6,7 @@ import { connect } from "react-redux";
 import {
   requestPasswordResetFormUpdate,
   requestPasswordReset
-} from "../../actions/request-password-reset";
+} from "redux-auth/actions/request-password-reset";
 
 class RequestPasswordResetForm extends React.Component {
   static propTypes = {

--- a/src/views/bootstrap/SignOutButton.js
+++ b/src/views/bootstrap/SignOutButton.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react";
 import ButtonLoader from "./ButtonLoader";
 import { Glyphicon } from "react-bootstrap";
 import { connect } from "react-redux";
-import { signOut } from "../../actions/sign-out";
+import { signOut } from "redux-auth/actions/sign-out";
 
 class SignOutButton extends React.Component {
   static propTypes = {

--- a/src/views/bootstrap/UpdatePasswordForm.js
+++ b/src/views/bootstrap/UpdatePasswordForm.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react";
 import Input from "./Input";
 import ButtonLoader from "./ButtonLoader";
 import { Glyphicon } from "react-bootstrap";
-import { updatePassword, updatePasswordFormUpdate } from "../../actions/update-password";
+import { updatePassword, updatePasswordFormUpdate } from "redux-auth/actions/update-password";
 import { connect } from "react-redux";
 
 class UpdatePasswordForm extends React.Component {

--- a/src/views/bootstrap/modals/DestroyAccountErrorModal.js
+++ b/src/views/bootstrap/modals/DestroyAccountErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideDestroyAccountErrorModal } from "../../../actions/ui";
+import { hideDestroyAccountErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class DestroyAccountErrorModal extends React.Component {

--- a/src/views/bootstrap/modals/DestroyAccountSuccessModal.js
+++ b/src/views/bootstrap/modals/DestroyAccountSuccessModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { hideDestroyAccountSuccessModal } from "../../../actions/ui";
+import { hideDestroyAccountSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class DestroyAccountSuccessModal extends React.Component {

--- a/src/views/bootstrap/modals/EmailSignInErrorModal.js
+++ b/src/views/bootstrap/modals/EmailSignInErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideEmailSignInErrorModal } from "../../../actions/ui";
+import { hideEmailSignInErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class EmailSignInErrorModal extends React.Component {

--- a/src/views/bootstrap/modals/EmailSignInSuccessModal.js
+++ b/src/views/bootstrap/modals/EmailSignInSuccessModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { hideEmailSignInSuccessModal } from "../../../actions/ui";
+import { hideEmailSignInSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class EmailSignInSuccessModal extends React.Component {

--- a/src/views/bootstrap/modals/EmailSignUpErrorModal.js
+++ b/src/views/bootstrap/modals/EmailSignUpErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideEmailSignUpErrorModal } from "../../../actions/ui";
+import { hideEmailSignUpErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class EmailSignUpErrorModal extends React.Component {

--- a/src/views/bootstrap/modals/EmailSignUpSuccessModal.js
+++ b/src/views/bootstrap/modals/EmailSignUpSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideEmailSignUpSuccessModal } from "../../../actions/ui";
+import { hideEmailSignUpSuccessModal } from "redux-auth/actions/ui";
 import { connect } from "react-redux";
 import Modal from "./Modal";
 

--- a/src/views/bootstrap/modals/FirstTimeLoginErrorModal.js
+++ b/src/views/bootstrap/modals/FirstTimeLoginErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideFirstTimeLoginErrorModal } from "../../../actions/ui";
+import { hideFirstTimeLoginErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class FirstTimeLoginErrorModal extends React.Component {

--- a/src/views/bootstrap/modals/FirstTimeLoginSuccessModal.js
+++ b/src/views/bootstrap/modals/FirstTimeLoginSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideFirstTimeLoginSuccessModal } from "../../../actions/ui";
+import { hideFirstTimeLoginSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 import { connect } from "react-redux";
 

--- a/src/views/bootstrap/modals/OAuthSignInErrorModal.js
+++ b/src/views/bootstrap/modals/OAuthSignInErrorModal.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Glyphicon } from "react-bootstrap";
 import Modal from "./Modal";
-import { hideOAuthSignInErrorModal } from "../../../actions/ui";
+import { hideOAuthSignInErrorModal } from "redux-auth/actions/ui";
 
 class OAuthSignInErrorModal extends React.Component {
   render () {

--- a/src/views/bootstrap/modals/OAuthSignInSuccessModal.js
+++ b/src/views/bootstrap/modals/OAuthSignInSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideOAuthSignInSuccessModal } from "../../../actions/ui";
+import { hideOAuthSignInSuccessModal } from "redux-auth/actions/ui";
 import { connect } from "react-redux";
 import Modal from "./Modal"
 

--- a/src/views/bootstrap/modals/PasswordResetSuccessModal.js
+++ b/src/views/bootstrap/modals/PasswordResetSuccessModal.js
@@ -3,11 +3,11 @@ import { Modal, Button, Glyphicon } from "react-bootstrap";
 import ButtonLoader from "../ButtonLoader";
 import Input from "../Input";
 import { connect } from "react-redux";
-import { hidePasswordResetSuccessModal } from "../../../actions/ui";
+import { hidePasswordResetSuccessModal } from "redux-auth/actions/ui";
 import {
   updatePasswordModal,
   updatePasswordModalFormUpdate
-} from "../../../actions/update-password-modal";
+} from "redux-auth/actions/update-password-modal";
 
 class PasswordResetSuccessModal extends React.Component {
   static propTypes = {

--- a/src/views/bootstrap/modals/RequestPasswordResetErrorModal.js
+++ b/src/views/bootstrap/modals/RequestPasswordResetErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hidePasswordResetRequestErrorModal } from "../../../actions/ui";
+import { hidePasswordResetRequestErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class RequestPasswordResetErrorModal extends React.Component {

--- a/src/views/bootstrap/modals/RequestPasswordResetSuccessModal.js
+++ b/src/views/bootstrap/modals/RequestPasswordResetSuccessModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { hidePasswordResetRequestSuccessModal } from "../../../actions/ui";
+import { hidePasswordResetRequestSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class RequestPasswordResetSuccessModal extends React.Component {

--- a/src/views/bootstrap/modals/SignOutErrorModal.js
+++ b/src/views/bootstrap/modals/SignOutErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideSignOutErrorModal } from "../../../actions/ui";
+import { hideSignOutErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class SignOutErrorModal extends React.Component {

--- a/src/views/bootstrap/modals/SignOutSuccessModal.js
+++ b/src/views/bootstrap/modals/SignOutSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideSignOutSuccessModal } from "../../../actions/ui";
+import { hideSignOutSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class SignOutSuccessModal extends React.Component {

--- a/src/views/bootstrap/modals/UpdatePasswordErrorModal.js
+++ b/src/views/bootstrap/modals/UpdatePasswordErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideUpdatePasswordErrorModal } from "../../../actions/ui";
+import { hideUpdatePasswordErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class UpdatePasswordErrorModal extends React.Component {

--- a/src/views/bootstrap/modals/UpdatePasswordSuccessModal.js
+++ b/src/views/bootstrap/modals/UpdatePasswordSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideUpdatePasswordSuccessModal } from "../../../actions/ui";
+import { hideUpdatePasswordSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class UpdatePasswordSuccessModal extends React.Component {

--- a/src/views/default/DestroyAccountButton.js
+++ b/src/views/default/DestroyAccountButton.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
 import ButtonLoader from "./ButtonLoader";
-import { destroyAccount } from "../../actions/destroy-account";
+import { destroyAccount } from "redux-auth/actions/destroy-account";
 import { connect } from "react-redux";
 
 class DestroyAccountButton extends React.Component {

--- a/src/views/default/EmailSignInForm.js
+++ b/src/views/default/EmailSignInForm.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import ButtonLoader from "./ButtonLoader";
 import Input from "./Input";
-import { emailSignInFormUpdate, emailSignIn } from "../../actions/email-sign-in";
+import { emailSignInFormUpdate, emailSignIn } from "redux-auth/actions/email-sign-in";
 import { connect } from "react-redux";
 
 class EmailSignInForm extends React.Component {

--- a/src/views/default/EmailSignUpForm.js
+++ b/src/views/default/EmailSignUpForm.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import Input from "./Input";
 import ButtonLoader from "./ButtonLoader";
-import { emailSignUpFormUpdate, emailSignUp } from "../../actions/email-sign-up";
+import { emailSignUpFormUpdate, emailSignUp } from "redux-auth/actions/email-sign-up";
 import { connect } from "react-redux";
 
 class EmailSignUpForm extends React.Component {

--- a/src/views/default/OAuthSignInButton.js
+++ b/src/views/default/OAuthSignInButton.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import { connect } from "react-redux";
 import ButtonLoader from "./ButtonLoader";
-import { oAuthSignIn as _oAuthSignIn } from "../../actions/oauth-sign-in";
+import { oAuthSignIn as _oAuthSignIn } from "redux-auth/actions/oauth-sign-in";
 
 // hook for rewire
 var oAuthSignIn = _oAuthSignIn;

--- a/src/views/default/RequestPasswordResetForm.js
+++ b/src/views/default/RequestPasswordResetForm.js
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import {
   requestPasswordResetFormUpdate,
   requestPasswordReset
-} from "../../actions/request-password-reset";
+} from "redux-auth/actions/request-password-reset";
 
 class RequestPasswordResetForm extends React.Component {
   static propTypes = {

--- a/src/views/default/SignOutButton.js
+++ b/src/views/default/SignOutButton.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import ButtonLoader from "./ButtonLoader";
 import { connect } from "react-redux";
-import { signOut } from "../../actions/sign-out";
+import { signOut } from "redux-auth/actions/sign-out";
 
 class SignOutButton extends React.Component {
   static propTypes = {

--- a/src/views/default/UpdatePasswordForm.js
+++ b/src/views/default/UpdatePasswordForm.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import Input from "./Input";
 import ButtonLoader from "./ButtonLoader";
-import { updatePassword, updatePasswordFormUpdate } from "../../actions/update-password";
+import { updatePassword, updatePasswordFormUpdate } from "redux-auth/actions/update-password";
 import { connect } from "react-redux";
 
 class UpdatePasswordForm extends React.Component {

--- a/src/views/default/modals/DestroyAccountErrorModal.js
+++ b/src/views/default/modals/DestroyAccountErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideDestroyAccountErrorModal } from "../../../actions/ui";
+import { hideDestroyAccountErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class DestroyAccountErrorModal extends React.Component {

--- a/src/views/default/modals/DestroyAccountSuccessModal.js
+++ b/src/views/default/modals/DestroyAccountSuccessModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { hideDestroyAccountSuccessModal } from "../../../actions/ui";
+import { hideDestroyAccountSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class DestroyAccountSuccessModal extends React.Component {

--- a/src/views/default/modals/EmailSignInErrorModal.js
+++ b/src/views/default/modals/EmailSignInErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideEmailSignInErrorModal } from "../../../actions/ui";
+import { hideEmailSignInErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class EmailSignInErrorModal extends React.Component {

--- a/src/views/default/modals/EmailSignInSuccessModal.js
+++ b/src/views/default/modals/EmailSignInSuccessModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { hideEmailSignInSuccessModal } from "../../../actions/ui";
+import { hideEmailSignInSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class EmailSignInSuccessModal extends React.Component {

--- a/src/views/default/modals/EmailSignUpErrorModal.js
+++ b/src/views/default/modals/EmailSignUpErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideEmailSignUpErrorModal } from "../../../actions/ui";
+import { hideEmailSignUpErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class EmailSignUpErrorModal extends React.Component {

--- a/src/views/default/modals/EmailSignUpSuccessModal.js
+++ b/src/views/default/modals/EmailSignUpSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideEmailSignUpSuccessModal } from "../../../actions/ui";
+import { hideEmailSignUpSuccessModal } from "redux-auth/actions/ui";
 import { connect } from "react-redux";
 import Modal from "./Modal";
 

--- a/src/views/default/modals/FirstTimeLoginErrorModal.js
+++ b/src/views/default/modals/FirstTimeLoginErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideFirstTimeLoginErrorModal } from "../../../actions/ui";
+import { hideFirstTimeLoginErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class FirstTimeLoginErrorModal extends React.Component {

--- a/src/views/default/modals/FirstTimeLoginSuccessModal.js
+++ b/src/views/default/modals/FirstTimeLoginSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideFirstTimeLoginSuccessModal } from "../../../actions/ui";
+import { hideFirstTimeLoginSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 import { connect } from "react-redux";
 

--- a/src/views/default/modals/OAuthSignInErrorModal.js
+++ b/src/views/default/modals/OAuthSignInErrorModal.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Glyphicon } from "react-bootstrap";
 import Modal from "./Modal";
-import { hideOAuthSignInErrorModal } from "../../../actions/ui";
+import { hideOAuthSignInErrorModal } from "redux-auth/actions/ui";
 
 class OAuthSignInErrorModal extends React.Component {
   render () {

--- a/src/views/default/modals/OAuthSignInSuccessModal.js
+++ b/src/views/default/modals/OAuthSignInSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideOAuthSignInSuccessModal } from "../../../actions/ui";
+import { hideOAuthSignInSuccessModal } from "redux-auth/actions/ui";
 import { connect } from "react-redux";
 import Modal from "./Modal"
 

--- a/src/views/default/modals/PasswordResetSuccessModal.js
+++ b/src/views/default/modals/PasswordResetSuccessModal.js
@@ -3,11 +3,11 @@ import { Modal, Button, Glyphicon } from "react-bootstrap";
 import ButtonLoader from "../ButtonLoader";
 import Input from "../Input";
 import { connect } from "react-redux";
-import { hidePasswordResetSuccessModal } from "../../../actions/ui";
+import { hidePasswordResetSuccessModal } from "redux-auth/actions/ui";
 import {
   updatePasswordModal,
   updatePasswordModalFormUpdate
-} from "../../../actions/update-password-modal";
+} from "redux-auth/actions/update-password-modal";
 
 class PasswordResetSuccessModal extends React.Component {
   static propTypes = {

--- a/src/views/default/modals/RequestPasswordResetErrorModal.js
+++ b/src/views/default/modals/RequestPasswordResetErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hidePasswordResetRequestErrorModal } from "../../../actions/ui";
+import { hidePasswordResetRequestErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class RequestPasswordResetErrorModal extends React.Component {

--- a/src/views/default/modals/RequestPasswordResetSuccessModal.js
+++ b/src/views/default/modals/RequestPasswordResetSuccessModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { hidePasswordResetRequestSuccessModal } from "../../../actions/ui";
+import { hidePasswordResetRequestSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class RequestPasswordResetSuccessModal extends React.Component {

--- a/src/views/default/modals/SignOutErrorModal.js
+++ b/src/views/default/modals/SignOutErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideSignOutErrorModal } from "../../../actions/ui";
+import { hideSignOutErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class SignOutErrorModal extends React.Component {

--- a/src/views/default/modals/SignOutSuccessModal.js
+++ b/src/views/default/modals/SignOutSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideSignOutSuccessModal } from "../../../actions/ui";
+import { hideSignOutSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class SignOutSuccessModal extends React.Component {

--- a/src/views/default/modals/UpdatePasswordErrorModal.js
+++ b/src/views/default/modals/UpdatePasswordErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideUpdatePasswordErrorModal } from "../../../actions/ui";
+import { hideUpdatePasswordErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class UpdatePasswordErrorModal extends React.Component {

--- a/src/views/default/modals/UpdatePasswordSuccessModal.js
+++ b/src/views/default/modals/UpdatePasswordSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideUpdatePasswordSuccessModal } from "../../../actions/ui";
+import { hideUpdatePasswordSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class UpdatePasswordSuccessModal extends React.Component {

--- a/src/views/material-ui/DestroyAccountButton.js
+++ b/src/views/material-ui/DestroyAccountButton.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
 import ButtonLoader from "./ButtonLoader";
-import { destroyAccount } from "../../actions/destroy-account";
+import { destroyAccount } from "redux-auth/actions/destroy-account";
 import {ActionDelete} from "material-ui/lib/svg-icons";
 import { connect } from "react-redux";
 

--- a/src/views/material-ui/EmailSignInForm.js
+++ b/src/views/material-ui/EmailSignInForm.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import ButtonLoader from "./ButtonLoader";
 import Input from "./Input";
-import { emailSignInFormUpdate, emailSignIn } from "../../actions/email-sign-in";
+import { emailSignInFormUpdate, emailSignIn } from "redux-auth/actions/email-sign-in";
 import {ActionExitToApp} from "material-ui/lib/svg-icons";
 import { connect } from "react-redux";
 

--- a/src/views/material-ui/EmailSignUpForm.js
+++ b/src/views/material-ui/EmailSignUpForm.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 import Input from "./Input";
 import ButtonLoader from "./ButtonLoader";
-import { emailSignUpFormUpdate, emailSignUp } from "../../actions/email-sign-up";
+import { emailSignUpFormUpdate, emailSignUp } from "redux-auth/actions/email-sign-up";
 import { connect } from "react-redux";
 import {ContentSend} from "material-ui/lib/svg-icons";
 

--- a/src/views/material-ui/OAuthSignInButton.js
+++ b/src/views/material-ui/OAuthSignInButton.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react";
 import { connect } from "react-redux";
 import ButtonLoader from "./ButtonLoader";
 import {ActionExitToApp} from "material-ui/lib/svg-icons";
-import { oAuthSignIn as _oAuthSignIn } from "../../actions/oauth-sign-in";
+import { oAuthSignIn as _oAuthSignIn } from "redux-auth/actions/oauth-sign-in";
 
 // hook for rewire
 var oAuthSignIn = _oAuthSignIn;

--- a/src/views/material-ui/RequestPasswordResetForm.js
+++ b/src/views/material-ui/RequestPasswordResetForm.js
@@ -6,7 +6,7 @@ import {ContentSend} from "material-ui/lib/svg-icons";
 import {
   requestPasswordResetFormUpdate,
   requestPasswordReset
-} from "../../actions/request-password-reset";
+} from "redux-auth/actions/request-password-reset";
 
 class RequestPasswordResetForm extends React.Component {
   static propTypes = {

--- a/src/views/material-ui/SignOutButton.js
+++ b/src/views/material-ui/SignOutButton.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react";
 import ButtonLoader from "./ButtonLoader";
 import { ActionLock } from "material-ui/lib/svg-icons";
 import { connect } from "react-redux";
-import { signOut } from "../../actions/sign-out";
+import { signOut } from "redux-auth/actions/sign-out";
 
 class SignOutButton extends React.Component {
   static propTypes = {

--- a/src/views/material-ui/UpdatePasswordForm.js
+++ b/src/views/material-ui/UpdatePasswordForm.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react";
 import Input from "./Input";
 import ButtonLoader from "./ButtonLoader";
 import { ActionLock } from "material-ui/lib/svg-icons";
-import { updatePassword, updatePasswordFormUpdate } from "../../actions/update-password";
+import { updatePassword, updatePasswordFormUpdate } from "redux-auth/actions/update-password";
 import { connect } from "react-redux";
 
 class UpdatePasswordForm extends React.Component {

--- a/src/views/material-ui/modals/DestroyAccountErrorModal.js
+++ b/src/views/material-ui/modals/DestroyAccountErrorModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Modal from "./Modal";
-import { hideDestroyAccountErrorModal } from "../../../actions/ui";
+import { hideDestroyAccountErrorModal } from "redux-auth/actions/ui";
 
 class DestroyAccountErrorModal extends React.Component {
   render () {

--- a/src/views/material-ui/modals/DestroyAccountSuccessModal.js
+++ b/src/views/material-ui/modals/DestroyAccountSuccessModal.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Modal from "./Modal";
 import { connect } from "react-redux";
-import { hideDestroyAccountSuccessModal } from "../../../actions/ui";
+import { hideDestroyAccountSuccessModal } from "redux-auth/actions/ui";
 
 class DestroyAccountSuccessModal extends React.Component {
   render () {

--- a/src/views/material-ui/modals/EmailSignInErrorModal.js
+++ b/src/views/material-ui/modals/EmailSignInErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideEmailSignInErrorModal } from "../../../actions/ui";
+import { hideEmailSignInErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class EmailSignInErrorModal extends React.Component {

--- a/src/views/material-ui/modals/EmailSignInSuccessModal.js
+++ b/src/views/material-ui/modals/EmailSignInSuccessModal.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Modal from "./Modal";
 import { connect } from "react-redux";
-import { hideEmailSignInSuccessModal } from "../../../actions/ui";
+import { hideEmailSignInSuccessModal } from "redux-auth/actions/ui";
 
 class EmailSignInSuccessModal extends React.Component {
   render () {

--- a/src/views/material-ui/modals/EmailSignUpErrorModal.js
+++ b/src/views/material-ui/modals/EmailSignUpErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideEmailSignUpErrorModal } from "../../../actions/ui";
+import { hideEmailSignUpErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class EmailSignUpErrorModal extends React.Component {

--- a/src/views/material-ui/modals/EmailSignUpSuccessModal.js
+++ b/src/views/material-ui/modals/EmailSignUpSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideEmailSignUpSuccessModal } from "../../../actions/ui";
+import { hideEmailSignUpSuccessModal } from "redux-auth/actions/ui";
 import { connect } from "react-redux";
 import Modal from "./Modal";
 

--- a/src/views/material-ui/modals/FirstTimeLoginErrorModal.js
+++ b/src/views/material-ui/modals/FirstTimeLoginErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideFirstTimeLoginErrorModal } from "../../../actions/ui";
+import { hideFirstTimeLoginErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class FirstTimeLoginErrorModal extends React.Component {

--- a/src/views/material-ui/modals/FirstTimeLoginSuccessModal.js
+++ b/src/views/material-ui/modals/FirstTimeLoginSuccessModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { hideFirstTimeLoginSuccessModal } from "../../../actions/ui";
+import { hideFirstTimeLoginSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class FirstTimeLoginSuccessModal extends React.Component {

--- a/src/views/material-ui/modals/OAuthSignInErrorModal.js
+++ b/src/views/material-ui/modals/OAuthSignInErrorModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Colors from "material-ui/lib/styles/colors";
-import { hideOAuthSignInErrorModal } from "../../../actions/ui";
+import { hideOAuthSignInErrorModal } from "redux-auth/actions/ui";
 import {AlertError} from "material-ui/lib/svg-icons";
 import Modal from "./Modal";
 

--- a/src/views/material-ui/modals/OAuthSignInSuccessModal.js
+++ b/src/views/material-ui/modals/OAuthSignInSuccessModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { hideOAuthSignInSuccessModal } from "../../../actions/ui";
+import { hideOAuthSignInSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class OAuthSignInSuccessModal extends React.Component {

--- a/src/views/material-ui/modals/PasswordResetSuccessModal.js
+++ b/src/views/material-ui/modals/PasswordResetSuccessModal.js
@@ -4,11 +4,11 @@ import { Dialog, FlatButton } from "material-ui";
 import ButtonLoader from "../ButtonLoader";
 import Input from "../Input";
 import { connect } from "react-redux";
-import { hidePasswordResetSuccessModal } from "../../../actions/ui";
+import { hidePasswordResetSuccessModal } from "redux-auth/actions/ui";
 import {
   updatePasswordModal,
   updatePasswordModalFormUpdate
-} from "../../../actions/update-password-modal";
+} from "redux-auth/actions/update-password-modal";
 
 class PasswordResetSuccessModal extends React.Component {
   static propTypes = {

--- a/src/views/material-ui/modals/RequestPasswordResetErrorModal.js
+++ b/src/views/material-ui/modals/RequestPasswordResetErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hidePasswordResetRequestErrorModal } from "../../../actions/ui";
+import { hidePasswordResetRequestErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class RequestPasswordResetErrorModal extends React.Component {

--- a/src/views/material-ui/modals/RequestPasswordResetSuccessModal.js
+++ b/src/views/material-ui/modals/RequestPasswordResetSuccessModal.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { hidePasswordResetRequestSuccessModal } from "../../../actions/ui";
+import { hidePasswordResetRequestSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class RequestPasswordResetSuccessModal extends React.Component {

--- a/src/views/material-ui/modals/SignOutErrorModal.js
+++ b/src/views/material-ui/modals/SignOutErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideSignOutErrorModal } from "../../../actions/ui";
+import { hideSignOutErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class SignOutErrorModal extends React.Component {

--- a/src/views/material-ui/modals/SignOutSuccessModal.js
+++ b/src/views/material-ui/modals/SignOutSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideSignOutSuccessModal } from "../../../actions/ui";
+import { hideSignOutSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class SignOutSuccessModal extends React.Component {

--- a/src/views/material-ui/modals/UpdatePasswordErrorModal.js
+++ b/src/views/material-ui/modals/UpdatePasswordErrorModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideUpdatePasswordErrorModal } from "../../../actions/ui";
+import { hideUpdatePasswordErrorModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class UpdatePasswordErrorModal extends React.Component {

--- a/src/views/material-ui/modals/UpdatePasswordSuccessModal.js
+++ b/src/views/material-ui/modals/UpdatePasswordSuccessModal.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { hideUpdatePasswordSuccessModal } from "../../../actions/ui";
+import { hideUpdatePasswordSuccessModal } from "redux-auth/actions/ui";
 import Modal from "./Modal";
 
 class UpdatePasswordSuccessModal extends React.Component {

--- a/webpack.release.js
+++ b/webpack.release.js
@@ -9,6 +9,7 @@ module.exports = {
   entry:   {
     "index":             "./src/index",
     "bootstrap-theme":   "./src/views/bootstrap/index",
+    "default-theme":     "./src/views/default/index",
     "material-ui-theme": "./src/views/material-ui/index"
   },
   output:  {
@@ -18,7 +19,7 @@ module.exports = {
   },
   externals: [
     function(rtx, req, cb) {
-      if (/\.\.\/\.\.\//.test(req)) {
+      if (/^redux-auth/.test(req)) {
         return cb(null, "commonjs redux-auth");
       } else {
         cb();
@@ -31,7 +32,6 @@ module.exports = {
       "extend": "commonjs extend",
       "history": "commonjs history",
       "immutable": "commonjs immutable",
-      "isomorphic-fetch": "commonjs isomorphic-fetch",
       "isomorphic-fetch": "commonjs isomorphic-fetch",
       "query-string": "commonjs query-string",
       "querystring": "commonjs querystring",


### PR DESCRIPTION
From my digging into #31 it looks like it's caused by the webpack externals not working correctly with the default theme. I'm not sure if this is the best fix - my webpack knowledge is rather limited - but this seems to work. However, it does introduce a **breaking change** as users of the default theme will have to import using `'redux-auth/default-theme'`. 

As far as I can tell, the prior webpack config was marking the default theme as external so then when it tried to require redux-auth from itself it choked return an empty object.