### PR TITLE
Fix webpack config to allow default theme to function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,18 +68,5 @@ export {
   hideDestroyAccountErrorModal
 } from "./actions/ui";
 
-/* UI */
-export {
-  AuthGlobals,
-  EmailSignInForm,
-  EmailSignUpForm,
-  SignOutButton,
-  RequestPasswordResetForm,
-  OAuthSignInButton,
-  UpdatePasswordForm,
-  DestroyAccountButton,
-  TokenBridge
-} from "./views/default";
-
 /* utils */
 export {default as fetch} from "./utils/fetch";

--- a/test/views/destroy-account-button-test.js
+++ b/test/views/destroy-account-button-test.js
@@ -26,7 +26,7 @@ var requirePath,
 export default function() {
   describe("DestroyAccountButton", () => {
     [
-      "",
+      "/views/default",
       "/views/material-ui",
       "/views/bootstrap"
     ].forEach((theme) => {

--- a/test/views/email-sign-in-test.js
+++ b/test/views/email-sign-in-test.js
@@ -22,9 +22,9 @@ var successRespSpy,
 export default function() {
   describe("EmailSignInForm", () => {
     [
-      "",
+      "/views/default",
       "/views/material-ui",
-      "/views/bootstrap",
+      "/views/bootstrap"
     ].forEach((theme) => {
       var requirePath = `../../src${theme}`;
       var {EmailSignInForm} = require(requirePath);

--- a/test/views/email-sign-up-test.js
+++ b/test/views/email-sign-up-test.js
@@ -42,7 +42,7 @@ export default function() {
   describe("EmailSignUpForm", () => {
 
     [
-      "",
+      "/views/default",
       "/views/material-ui",
       "/views/bootstrap"
     ].forEach((theme) => {

--- a/test/views/modals-test.js
+++ b/test/views/modals-test.js
@@ -26,7 +26,7 @@ function findClass (className) {
 export default function() {
   describe("Modal visibility", () => {
     [
-      "",
+      "/views/default",
       "/views/bootstrap",
       "/views/material-ui"
     ].forEach((theme) => {

--- a/test/views/password-reset-test.js
+++ b/test/views/password-reset-test.js
@@ -26,9 +26,9 @@ var requirePath,
 export default function() {
   describe("RequestPasswordResetForm", () => {
     [
-      "",
+      "/views/default",
       "/views/bootstrap",
-      "/views/material-ui",
+      "/views/material-ui"
     ].forEach((theme) => {
       requirePath = `../../src${theme}`;
       var {RequestPasswordResetForm} = require(requirePath);

--- a/test/views/password-update-test.js
+++ b/test/views/password-update-test.js
@@ -50,7 +50,7 @@ var requirePath,
 export default function() {
   describe("UpdatePasswordForm", () => {
     [
-      "",
+      "/views/default",
       "/views/bootstrap",
       "/views/material-ui"
     ].forEach((theme) => {

--- a/test/views/sign-out-test.js
+++ b/test/views/sign-out-test.js
@@ -25,7 +25,7 @@ var requirePath,
 export default function() {
   describe("SignOutButton", () => {
     [
-      "",
+      "/views/default",
       "/views/bootstrap",
       "/views/material-ui"
     ].forEach((theme) => {

--- a/webpack.release.js
+++ b/webpack.release.js
@@ -9,6 +9,7 @@ module.exports = {
   entry:   {
     "index":             "./src/index",
     "bootstrap-theme":   "./src/views/bootstrap/index",
+    "default-theme":     "./src/views/default/index",
     "material-ui-theme": "./src/views/material-ui/index"
   },
   output:  {
@@ -31,7 +32,6 @@ module.exports = {
       "extend": "commonjs extend",
       "history": "commonjs history",
       "immutable": "commonjs immutable",
-      "isomorphic-fetch": "commonjs isomorphic-fetch",
       "isomorphic-fetch": "commonjs isomorphic-fetch",
       "query-string": "commonjs query-string",
       "querystring": "commonjs querystring",


### PR DESCRIPTION
From my digging into #31 it looks like it's caused by the webpack externals not working correctly with the default theme. I'm not sure if this is the best fix - my webpack knowledge is rather limited - but this seems to work. However, it does introduce a **breaking change** as users of the default theme will have to import using `'redux-auth/default-theme'`. 

As far as I can tell, the prior webpack config was marking the default theme as external. Then, when it tried to require redux-auth from itself, it choked and return an empty object.