### PR TITLE
updated readme, to include json loader dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ npm install react-bootstrap --save
 
 Material UI uses inline styles so no further configuration is needed. But with the bootstrap theme, the CSS will also need to be included. Read more at the [React Bootstrap][react-bootstrap] project page.
 
+You must also install and use a json loader
+
 --
 
 # Usage


### PR DESCRIPTION
Installing and using redux-auth straight up, without using a json loader will error like @woniesong92 from issue comment
https://github.com/lynndylanhurley/redux-auth/issues/26#issuecomment-211672155

Might make it easier to let everyone know about it at installation time
