### PR TITLE
pass the click event to the callback

### DIFF
--- a/src/views/default/ButtonLoader.js
+++ b/src/views/default/ButtonLoader.js
@@ -43,7 +43,7 @@ class ButtonLoader extends React.Component {
 
   handleClick (ev) {
     ev.preventDefault();
-    this.props.onClick();
+    this.props.onClick(ev);
   }
 
   renderIcon () {

--- a/src/views/material-ui/ButtonLoader.js
+++ b/src/views/material-ui/ButtonLoader.js
@@ -35,7 +35,7 @@ class ButtonLoader extends React.Component {
 
   handleClick (ev) {
     ev.preventDefault();
-    this.props.onClick();
+    this.props.onClick(ev);
   }
 
   getColor () {


### PR DESCRIPTION
The pull request https://github.com/lynndylanhurley/redux-auth/commit/b126755a09a31f998162ce71252342c74a0e32a5 broke the functionality of the EmailSignUpForm and EmailSignInForm in the default and the material-ui version. Both components expected an event object which was never passed to their callbacks causing that the submission was never done and ending into the exception

```
Uncaught TypeError: Cannot read property 'preventDefault' of undefined
```

This did not affect the bootstrap version since there the callback was passed directly to the react-bootstrap button which passes the event correctly to the callback.

Will fix issue https://github.com/lynndylanhurley/redux-auth/issues/34