### PR TITLE
 Persist credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ A form used to sign in using accounts that were registered by email.
 
 * **`endpoint`**: The key of the target provider service as represented in the endpoint configuration block.
 * **`inputProps`**: An object containing the following attributes:
-	* **`email`**: An object that will override the email input component's default props.
-	* **`password`**: An object that will override the password input component's default props.
-	* **`submit`**: An object that will override the submit button component's default props.
+  * **`email`**: An object that will override the email input component's default props.
+  * **`password`**: An object that will override the password input component's default props.
+  * **`submit`**: An object that will override the submit button component's default props.
 
 ~~~js
 // default theme
@@ -421,6 +421,9 @@ This must be run before your app is initialized. This should be run on both the 
   * **`cookies`**: A string representation of the cookies from the current request. This will be parsed for any auth credentials.
   * **`location`**: A string representation of the current request's URL.
 
+Additionaly when rendering on client side some additional settings can be passed in  **`settings`** object.
+  * **`cleanSession`**: A boolean that tells if all locally stored credentials will be flushed.
+  * **`serverSideRendering`**: A boolean that tells if serverside rendering is used, defaults to `true`. Enables the persist of credentials between sessions.
 --
 
 ##### configure example
@@ -444,7 +447,8 @@ store.dispatch(configure(
 
 // client-side usage
 store.dispatch(configure(
-  {apiUrl: "https://api.graveflex.com"}
+  {apiUrl: "https://api.graveflex.com"},
+  {serverSideRendering: true, cleanSession: true}
 )).then(() => {
   // your store should now have the current user. now render your
   // app to the DOM. see the demo app for a more complete example.

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ This must be run before your app is initialized. This should be run on both the 
 
 Additionaly when rendering on client side some additional settings can be passed in  **`settings`** object.
   * **`cleanSession`**: A boolean that tells if all locally stored credentials will be flushed.
-  * **`serverSideRendering`**: A boolean that tells if serverside rendering is used, defaults to `true`. Enables the persist of credentials between sessions.
+  * **`clientOnly`**: A boolean that tells if code is run only on client side. Should be set `true` with only client-side usage.
 --
 
 ##### configure example

--- a/src/actions/configure.js
+++ b/src/actions/configure.js
@@ -114,10 +114,9 @@ export function configure(endpoint={}, settings={}) {
         settings.initialCredentials = extend({}, settings.initialCredentials, authRedirectHeaders);
       }
 
-      let serverSideRendering = settings.serverSideRendering === undefined || settings.serverSideRendering;
       // if tokens were invalidated by server or from the settings, make sure
       // to clear browser credentials
-      if (serverSideRendering && !settings.initialCredentials || settings.cleanSession) {
+      if (!settings.clientOnly && !settings.initialCredentials || settings.cleanSession) {
         destroySession();
       }
 

--- a/src/actions/configure.js
+++ b/src/actions/configure.js
@@ -114,9 +114,10 @@ export function configure(endpoint={}, settings={}) {
         settings.initialCredentials = extend({}, settings.initialCredentials, authRedirectHeaders);
       }
 
-      // if tokens were invalidated by server, make sure to clear browser
-      // credentials
-      if (!settings.initialCredentials) {
+      let serverSideRendering = settings.serverSideRendering === undefined || settings.serverSideRendering;
+      // if tokens were invalidated by server or from the settings, make sure
+      // to clear browser credentials
+      if (serverSideRendering && !settings.initialCredentials || settings.cleanSession) {
         destroySession();
       }
 

--- a/src/utils/client-settings.js
+++ b/src/utils/client-settings.js
@@ -4,6 +4,7 @@ import fetch from "./fetch";
 import parseEndpointConfig from "./parse-endpoint-config";
 import {setEndpointKeys} from "../actions/configure";
 import {
+  getApiUrl,
   getCurrentSettings,
   setCurrentSettings,
   getInitialEndpointKey,
@@ -93,12 +94,12 @@ export function applyConfig({dispatch, endpoint={}, settings={}, reset=false}={}
 
   if (getCurrentSettings().initialCredentials) {
     // skip initial headers check (i.e. check was already done server-side)
-    let {user, headers, config} = getCurrentSettings().initialCredentials;
+    let {user, headers} = getCurrentSettings().initialCredentials;
     persistData(C.SAVED_CREDS_KEY, headers);
     return Promise.resolve(user);
   } else if (savedCreds) {
     // verify session credentials with API
-    return fetch(savedCreds)
+    return fetch(getApiUrl(currentEndpointKey))
   } else {
     return Promise.reject({reason: "No credentials."})
   }

--- a/src/utils/client-settings.js
+++ b/src/utils/client-settings.js
@@ -11,6 +11,7 @@ import {
   setDefaultEndpointKey,
   setCurrentEndpoint,
   setCurrentEndpointKey,
+  removeData,
   retrieveData,
   persistData
 } from "./session-storage";
@@ -99,7 +100,14 @@ export function applyConfig({dispatch, endpoint={}, settings={}, reset=false}={}
     return Promise.resolve(user);
   } else if (savedCreds) {
     // verify session credentials with API
-    return fetch(getApiUrl(currentEndpointKey))
+    return fetch(`${getApiUrl(currentEndpointKey)}${currentEndpoint[currentEndpointKey].tokenValidationPath}`)
+    .then(response => {
+          if (response.status >= 200 && response.status < 300) {
+            return response.json().then(({ data }) => (data));
+          }
+          removeData(C.SAVED_CREDS_KEY);
+          return Promise.reject({reason: "No credentials."});
+    });
   } else {
     return Promise.reject({reason: "No credentials."})
   }

--- a/src/utils/session-storage.js
+++ b/src/utils/session-storage.js
@@ -164,6 +164,17 @@ export function getTokenFormat() {
   return root.authState.currentSettings.tokenFormat;
 }
 
+export function removeData(key) {
+
+  switch(root.authState.currentSettings.storage) {
+    case "localStorage":
+      root.localStorage.removeItem(key);
+      break;
+    default:
+      Cookies.remove(key);
+  }
+}
+
 export function persistData (key, val) {
   val = JSON.stringify(val);
 
@@ -182,10 +193,10 @@ export function persistData (key, val) {
 };
 
 
-export function retrieveData (key) {
+export function retrieveData (key, storage) {
   var val = null;
 
-  switch (root.authState.currentSettings.storage) {
+  switch (storage || root.authState.currentSettings.storage) {
     case "localStorage":
       val = root.localStorage && root.localStorage.getItem(key);
       break;

--- a/src/views/default/ButtonLoader.js
+++ b/src/views/default/ButtonLoader.js
@@ -43,7 +43,7 @@ class ButtonLoader extends React.Component {
 
   handleClick (ev) {
     ev.preventDefault();
-    this.props.onClick();
+    this.props.onClick(ev);
   }
 
   renderIcon () {

--- a/src/views/default/ButtonLoader.js
+++ b/src/views/default/ButtonLoader.js
@@ -43,7 +43,7 @@ class ButtonLoader extends React.Component {
 
   handleClick (ev) {
     ev.preventDefault();
-    this.props.onClick(ev);
+    this.props.onClick();
   }
 
   renderIcon () {

--- a/src/views/material-ui/ButtonLoader.js
+++ b/src/views/material-ui/ButtonLoader.js
@@ -35,7 +35,7 @@ class ButtonLoader extends React.Component {
 
   handleClick (ev) {
     ev.preventDefault();
-    this.props.onClick(ev);
+    this.props.onClick();
   }
 
   getColor () {

--- a/src/views/material-ui/ButtonLoader.js
+++ b/src/views/material-ui/ButtonLoader.js
@@ -35,7 +35,7 @@ class ButtonLoader extends React.Component {
 
   handleClick (ev) {
     ev.preventDefault();
-    this.props.onClick();
+    this.props.onClick(ev);
   }
 
   getColor () {


### PR DESCRIPTION
This should fix the issues https://github.com/lynndylanhurley/redux-auth/issues/47 and https://github.com/lynndylanhurley/redux-auth/issues/11.

The main problem seems to be that the configuration is made with the assumption that it is used with serverside rendering. The idea seems to be that if the server invalidates credentials via TokenBridge the session would be destroyed. Since TokenBridge is not used on client-only usage the initialCredentials are allways undefined causing the call of destroying the session.

If I understood correctly from this https://github.com/lynndylanhurley/redux-auth/issues/7#issuecomment-168371725, there will be full support for client-only usage. Currently client-only usage seems to work at some extend and with this fix it becomes more usable when every page reload is not anymore clearing the sessions. As said here https://github.com/lynndylanhurley/redux-auth/issues/23#issuecomment-186673571 the real fix is to make a completely different configuration for client-only usage but meanwhile this should make the library a bit more usable client-only.

I noticed also that it was possible to pass `storage: 'localStorage'` with the settings to get the the persisting to happen in to the localStorage. This was an undocumented feature and was not sure if there is something that doesn't work when used. So far couldn't find any difference with cookies vs localstorage persiting.

This fixes also a bug where fetch was called with the saved headers as parameter instead of the api-url.

Added also an extra option so it could be possible to configure the and run the configure so that it is possible to flush credentials with client only usage.