### PR TITLE
Transport bearer token in accordance to RFC 6750

### DIFF
--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -13,6 +13,19 @@ var isApiRequest = function(url) {
   return (url.match(getApiUrl(getSessionEndpointKey())));
 };
 
+/**
+ * Add access token as a bearer token in accordance to RFC 6750
+ *
+ * @param {string} accessToken
+ * @param {object} headers
+ * @returns {object} New extended headers object, with Authorization property
+ */
+export function addAuthorizationHeader(accessToken, headers) {
+  return Object.assign({}, headers, {
+    Authorization: `Bearer ${accessToken}`
+  });
+}
+
 function getAuthHeaders(url) {
   if (isApiRequest(url)) {
     // fetch current auth headers from storage
@@ -22,15 +35,12 @@ function getAuthHeaders(url) {
     // bust IE cache
     nextHeaders["If-Modified-Since"] = "Mon, 26 Jul 1997 05:00:00 GMT";
 
-    // transport access token as a bearer token in accordance to RFC 6750
-    nextHeaders["Authorization"] = `Bearer ${currentHeaders['access-token']}`;
-
     // set header for each key in `tokenFormat` config
     for (var key in getTokenFormat()) {
       nextHeaders[key] = currentHeaders[key];
     }
 
-    return nextHeaders;
+    return addAuthorizationHeader(currentHeaders['access-token'], nextHeaders);
   } else {
     return {};
   }

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -22,6 +22,9 @@ function getAuthHeaders(url) {
     // bust IE cache
     nextHeaders["If-Modified-Since"] = "Mon, 26 Jul 1997 05:00:00 GMT";
 
+    // transport access token as a bearer token in accordance to RFC 6750
+    nextHeaders["Authorization"] = `Bearer ${currentHeaders['access-token']}`;
+
     // set header for each key in `tokenFormat` config
     for (var key in getTokenFormat()) {
       nextHeaders[key] = currentHeaders[key];

--- a/src/utils/verify-auth.js
+++ b/src/utils/verify-auth.js
@@ -2,6 +2,7 @@ import fetch from "isomorphic-fetch";
 import cookie from "cookie";
 import getRedirectInfo from "../utils/parse-url";
 import * as C from "../utils/constants";
+import { addAuthorizationHeader } from "../utils/fetch";
 import parseEndpointConfig from "./parse-endpoint-config";
 import url from "url";
 
@@ -73,7 +74,7 @@ export function fetchToken({rawEndpoints, cookies, currentLocation}) {
           validationUrl = `${apiUrl}${tokenValidationPath}?unbatch=true`;
 
       return fetch(validationUrl, {
-        headers
+        headers: addAuthorizationHeader(headers['access-token'], headers)
       }).then((resp) => {
         newHeaders = parseHeaders(resp.headers.raw());
         return resp.json();


### PR DESCRIPTION
This is needed to work with https://github.com/FloeDesignTechnologies/passport-http-jwt-bearer and any other package working with bearer tokens in a standard way.