### PR TITLE
Fix duplicate props on UpdatePasswordForm

### DIFF
--- a/src/views/bootstrap/UpdatePasswordForm.js
+++ b/src/views/bootstrap/UpdatePasswordForm.js
@@ -73,11 +73,9 @@ class UpdatePasswordForm extends React.Component {
 
         <ButtonLoader loading={loading}
                       type="submit"
-                      className="pull-right"
-                      icon={this.props.icon}
+                      className="pull-right update-password-submit"
+                      icon={this.props.icon || <Glyphicon glyph="lock"/>}
                       disabled={disabled}
-                      className="update-password-submit"
-                      icon={<Glyphicon glyph="lock" />}
                       onClick={this.handleSubmit.bind(this)}
                       {...this.props.inputProps.submit}>
           Update Password


### PR DESCRIPTION
Some of the properties passed from the UpdatePasswordForm to its ButtonLoader were duplicated.  This generates bad Javascript that chokes up certain interpreters (i.e. PhantomJS).  