### PR TITLE
fix updatePasswordModal loading

### DIFF
--- a/src/actions/update-password-modal.js
+++ b/src/actions/update-password-modal.js
@@ -11,7 +11,7 @@ export function updatePasswordModalFormUpdate(endpoint, key, value) {
   return { type: UPDATE_PASSWORD_MODAL_FORM_UPDATE, endpoint, key, value };
 }
 export function updatePasswordModalStart(endpoint) {
-  return { type: UPDATE_PASSWORD_MODAL_START };
+  return { type: UPDATE_PASSWORD_MODAL_START, endpoint };
 }
 export function updatePasswordModalComplete(endpoint, user) {
   return { type: UPDATE_PASSWORD_MODAL_COMPLETE, endpoint, user };


### PR DESCRIPTION
It appears that `UPDATE_PASSWORD_MODAL_START` action wasn't updating the store correctly.

This appears to fix it by adding the `endpoint` property. 