### PR TITLE
Add missing ending parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ server.ext("onPreResponse", (request, reply) => {
   }).then(appComponent => {
     reply(getMarkup(appComponent));
   });
-}
+});
 ~~~
 
 ##### client side rendering configuration


### PR DESCRIPTION
This PR is to add the missing ending parenthesis to: 

```
server.ext("onPreResponse", (request, reply) => {
  const query = qs.stringify(request.query);
  const currentLocation = request.path + (query.length ? "?" + query : "");
  const cookies = request.headers.cookies;

  renderApp({
    isServer: true,
    cookies,
    currentLocation
  }).then(appComponent => {
    reply(getMarkup(appComponent));
  });
});
```